### PR TITLE
Fixes a problem with short long descriptions

### DIFF
--- a/webapps/jsp/portlet/gu/viewEventPublic.jsp
+++ b/webapps/jsp/portlet/gu/viewEventPublic.jsp
@@ -361,8 +361,8 @@
 				<ww:else>
 					<c:set var="longDescription"><ww:property value="#eventVersion.longDescription" escape="true"/></c:set>
 					<%
-						String decoratedLongDescription = (String)pageContext.getAttribute("longDescription");
-						decoratedLongDescription = decoratedLongDescription.substring(0, 250);
+						String decoratedLongDescription = (String)pageContext.getAttribute("longDescription");						int descriptionLength = Math.min(250, decoratedLongDescription.length());
+						decoratedLongDescription = decoratedLongDescription.substring(0, descriptionLength);
 						pageContext.setAttribute("longDescription", decoratedLongDescription);
 					%>
 					<c:out value="${longDescription}"></c:out>


### PR DESCRIPTION
When no short description is provided an extract from the long description
is used. If the long description was to short an exception was thrown.

It looks like the Github diff is broken again. Here follows command for diffing

`
git diff 2858b6ab939f413f4e9c6087b72b8848b0e83 c259976f93acf24e6f5ae2f2c42f50f857bf5
`
With GUI
`
git difftool 2858b6ab939f413f4e9c6087b72b8848b0e83 c259976f93acf24e6f5ae2f2c42f50f857bf5
`